### PR TITLE
Use SHA256 instead of SHA1 checksum

### DIFF
--- a/Formula/fzy.rb
+++ b/Formula/fzy.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Fzy < Formula
   homepage 'https://github.com/jhawthorn/fzy#readme'
   url 'https://github.com/jhawthorn/fzy/archive/0.7.tar.gz'
-  sha1 '0d45b6ebe4af521f0e81376ff6fc22ce48098a35'
+  sha256 '6eb0940c85518c32326e6d389de6a9ede695ed9846f8b78aafec1066b9720186'
 
   head 'https://github.com/jhawthorn/fzy.git'
 


### PR DESCRIPTION
Homebrew is [in the process of deprecating SHA1 checksums](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Checksum_Deprecation.md). When you do `brew install` with a package with SHA1 checksum, you'll get a warning, so it seems to me like a good time to upgrade.
