### PR TITLE
SHA1 is deprecated, use SHA256

### DIFF
--- a/Formula/fzy.rb
+++ b/Formula/fzy.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Fzy < Formula
   homepage 'https://github.com/jhawthorn/fzy#readme'
   url 'https://github.com/jhawthorn/fzy/archive/0.7.tar.gz'
-  sha1 '0d45b6ebe4af521f0e81376ff6fc22ce48098a35'
+  sha256 '6eb0940c85518c32326e6d389de6a9ede695ed9846f8b78aafec1066b9720186'
 
   head 'https://github.com/jhawthorn/fzy.git'
 


### PR DESCRIPTION
A run of `brew doctor` will point out that SHA1 is deprecated:

```
Warning: Calling SoftwareSpec#sha1 is deprecated!
Use SoftwareSpec#sha256 instead.
/usr/local/Library/Taps/jhawthorn/homebrew-fzy/Formula/fzy.rb:6:in `<class:Fzy>'
Please report this to the jhawthorn/fzy tap!
```

I haven't tested this change but it should fix it.
