### PR TITLE
Use SHA256 instead of deprecated SHA1

### DIFF
--- a/Formula/fzy.rb
+++ b/Formula/fzy.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Fzy < Formula
   homepage 'https://github.com/jhawthorn/fzy#readme'
   url 'https://github.com/jhawthorn/fzy/archive/0.7.tar.gz'
-  sha1 '0d45b6ebe4af521f0e81376ff6fc22ce48098a35'
+  sha256 '6eb0940c85518c32326e6d389de6a9ede695ed9846f8b78aafec1066b9720186'
 
   head 'https://github.com/jhawthorn/fzy.git'
 


### PR DESCRIPTION
Homebrew is currently spitting out the following errors for this formula:

```
Warning: Calling Formula.sha1 is deprecated!
Use Formula.sha256 instead.
/usr/local/Library/Taps/jhawthorn/homebrew-fzy/Formula/fzy.rb:6:in `<class:Fzy>'
Please report this to the jhawthorn/fzy tap!

Warning: Calling SoftwareSpec#sha1 is deprecated!
Use SoftwareSpec#sha256 instead.
/usr/local/Library/Taps/jhawthorn/homebrew-fzy/Formula/fzy.rb:6:in `<class:Fzy>'
Please report this to the jhawthorn/fzy tap!

Warning: Calling Resource#sha1 is deprecated!
Use Resource#sha256 instead.
/usr/local/Library/Taps/jhawthorn/homebrew-fzy/Formula/fzy.rb:6:in `<class:Fzy>'
Please report this to the jhawthorn/fzy tap!
```

Migrating from SHA1 to SHA256 fixes all of these errors. All Homebrew hashes should be SHA256.
